### PR TITLE
Add paramaters for paths of sudo and btrfs command

### DIFF
--- a/check_disk_btrfs
+++ b/check_disk_btrfs
@@ -162,12 +162,23 @@ def main():
     arg_parser.add_argument('-c', '--threshold-critical', type=int, default=90, help="critical threshold in percent")
     arg_parser.add_argument('-V', '--volume', default='/', help="btrfs volume") #TODO support multiple volumes
     arg_parser.add_argument("-v", "--verbose", action="store_true", help="increase output verbosity")
+    arg_parser.add_argument("--btrfs_path", default=None, help="Specify the btrfs path to the executable")
+    arg_parser.add_argument("--sudo_path", default=None, help="Specify the sudo path to the executable")
     args = arg_parser.parse_args(sys.argv[1:])
 
     global verbose
     verbose = args.verbose
 
+    if args.sudo_path is not None:
+        global sudo_path
+        sudo_path = args.sudo_path
+
+    if args.btrfs_path is not None:
+        global btrfs_path
+        btrfs_path = args.btrfs_path
+
     output = run_cmd(args.volume, args.timeout, args.sudo)
+
     if args.unallocated == 1:
         size_overall = get_size_overall(output)
 

--- a/check_disk_btrfs
+++ b/check_disk_btrfs
@@ -51,8 +51,8 @@ from subprocess import Popen, PIPE
 from argparse import ArgumentParser
 
 VERSION = '3.0.0'
-sudo_path = os.environ.get('SUDO', "/usr/bin/sudo")
-btrfs_path = os.environ.get('BTRFS', "/usr/sbin/btrfs")
+sudo_path = None
+btrfs_path = None
 verbose = True
 
 class BtrfsCommandError(Exception):
@@ -162,20 +162,14 @@ def main():
     arg_parser.add_argument('-c', '--threshold-critical', type=int, default=90, help="critical threshold in percent")
     arg_parser.add_argument('-V', '--volume', default='/', help="btrfs volume") #TODO support multiple volumes
     arg_parser.add_argument("-v", "--verbose", action="store_true", help="increase output verbosity")
-    arg_parser.add_argument("--btrfs_path", default=None, help="Specify the btrfs path to the executable")
-    arg_parser.add_argument("--sudo_path", default=None, help="Specify the sudo path to the executable")
+    arg_parser.add_argument("--btrfs_path", default=os.environ.get("BTRFS", "/usr/sbin/btrfs"), help="Specify the btrfs path to the executable")
+    arg_parser.add_argument("--sudo_path", default=os.environ.get("SUDO", "/usr/bin/sudo"), help="Specify the sudo path to the executable")
     args = arg_parser.parse_args(sys.argv[1:])
 
-    global verbose
+    global verbose, sudo_path, btrfs_path
     verbose = args.verbose
-
-    if args.sudo_path is not None:
-        global sudo_path
-        sudo_path = args.sudo_path
-
-    if args.btrfs_path is not None:
-        global btrfs_path
-        btrfs_path = args.btrfs_path
+    sudo_path = args.sudo_path
+    btrfs_path = args.btrfs_path
 
     output = run_cmd(args.volume, args.timeout, args.sudo)
 


### PR DESCRIPTION
This allows to pass paths of commands when it is not possible to set environments variables, like when you use by_ssh command