### PR TITLE
Change usage output to percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ optional arguments:
   --no-sudo             Disable sudo use
   -t TIMEOUT, --timeout TIMEOUT
                         Timeout in seconds for the CheckPlugin (default 30)
-  -U, --unallocated     Consider unallocated blocks by using overall size as total (Default True)
-  --no-unallocated      Do not consider unallocated blocks
+  -U, --unallocated     Consider unallocated blocks by using overall size as total
   -w THRESHOLD_WARNING, --threshold-warning THRESHOLD_WARNING
                         Warning threshold in percent
   -c THRESHOLD_CRITICAL, --threshold-critical THRESHOLD_CRITICAL
@@ -64,11 +63,7 @@ Example:
 ```
 check_disk_btrfs -V / -w 30 -c 40
 
-CRITICAL: 'Data, single': 47.59051% used (0.0GB/2.0GB) OK: 'System, single': 0.39063% used (0.0MB/4.0MB),
-'GlobalReserve, single': 0.0% used (0.0MB/16.0MB), 'Metadata, single': 16.41809% used (43.0MB/264.0MB)
-| data_single_used=1025990656;30;40;; data_single_total=2155872256;30;40;; system_single_used=16384;30;40;;
-system_single_total=4194304;30;40;; globalreserve_single_used=0;30;40;; globalreserve_single_total=16777216;30;40;;
-metadata_single_used=45449216;30;40;; metadata_single_total=276824064;30;40;;
+CRITICAL: 'Data,RAID1': 99.49% used OK: 'Metadata,RAID1': 27.04% used, 'System,RAID1': 0.20% used | dataraid1_used=466829971456;30;40;; dataraid1_total=469225177088;30;40;; metadataraid1_used=580681728;30;40;; metadataraid1_total=2147483648;30;40;; systemraid1_used=81920;30;40;; systemraid1_total=41943040;30;40;;
 ```
 
 ## Icinga 2 Integration
@@ -85,7 +80,6 @@ object CheckCommand "disk_btrfs" {
                 "-V" = "$disk_btrfs_volume$"
                 "-w" = "$disk_btrfs_warn$"
                 "-c" = "$disk_btrfs_crit$"
-                "-U" = "$disk_btrfs_unallocated$"
                 "-s" = "$disk_btrfs_sudo$"
                 "-m" = "$disk_btrfs_missing$"
                 "-e" = "$disk_btrfs_errors$"

--- a/check_disk_btrfs
+++ b/check_disk_btrfs
@@ -163,6 +163,10 @@ def parse_output(output):
     return values
 
 def find_hr_bytes(total, used):
+    """
+    Calculate usage.
+    Currently unused since we switched to simply calculating a usage in percentage
+    """
     val = float(total)
     byte_c = 0
     hr_label = "B"
@@ -199,9 +203,7 @@ def cli(args):
                         help="Disable sudo use")
 
     arg_parser.add_argument('-U', '--unallocated', action='store_true',
-                            help="Consider unallocated blocks by using overall size as total (Default True)")
-    arg_parser.add_argument('--no-unallocated', dest='unallocated', action='store_false',
-                            help="Do not consider unallocated blocks")
+                            help="Consider unallocated blocks by using overall size as total")
 
     arg_parser.add_argument('-t', '--timeout', type=int, default=30,
                             help="Timeout in seconds for the CheckPlugin (default 30)")
@@ -223,7 +225,6 @@ def cli(args):
                             help="Check for scrub errors in device")
 
     arg_parser.set_defaults(sudo=True)
-    arg_parser.set_defaults(unallocated=True)
 
     return arg_parser.parse_args(args)
 
@@ -242,9 +243,6 @@ def main(args):
             timeout=args.timeout,
             use_sudo=args.sudo)
 
-    if args.unallocated:
-        size_overall = get_size_overall(output)
-
     values = parse_output(output)
 
     ok = []
@@ -259,16 +257,13 @@ def main(args):
             continue
 
         # if we want to consider unallocated blocks, we have to set total to overall size
-        try:
-            total = size_overall
-        except NameError:
-            pass
+        if args.unallocated:
+            total = get_size_overall(output)
 
-        used_perc = round(float(used) / float(total) * 100, 5)
+        used_perc = round(int(used) / int(total) * 100, 2)
 
-        hr_label, hr_total, hr_used = find_hr_bytes(total, used)
+        out = "'{}': {:.2f}% used".format(label, used_perc)
 
-        out = "'%s': %s%% used (%s%s/%s%s)" % (label, used_perc, hr_used, hr_label, hr_total, hr_label)
         perf_label = label.lower().replace(" ", "_").replace(",", "")
         perf = "%s_used=%s;%s;%s;; %s_total=%s;%s;%s;;" % (perf_label, used, args.threshold_warning, args.threshold_critical, perf_label, total, args.threshold_warning, args.threshold_critical)
 

--- a/test_check_disk_btrfs.py
+++ b/test_check_disk_btrfs.py
@@ -117,6 +117,7 @@ class CLITesting(unittest.TestCase):
         self.assertTrue(actual.sudo)
         self.assertEqual(actual.timeout, 15)
         self.assertTrue(actual.verbose)
+        self.assertFalse(actual.unallocated)
 
         actual = cli(['--no-sudo'])
         self.assertFalse(actual.sudo)
@@ -124,9 +125,6 @@ class CLITesting(unittest.TestCase):
 
         actual = cli(['--unallocated'])
         self.assertTrue(actual.unallocated)
-
-        actual = cli(['--no-unallocated'])
-        self.assertFalse(actual.unallocated)
 
 class UtilTesting(unittest.TestCase):
 
@@ -220,7 +218,7 @@ class MainTesting(unittest.TestCase):
         args = cli(['--no-sudo', '-w', '30', '-c', '40', '-v', '--missing', '--error'])
         actual = main(args)
 
-        self.assertEqual(actual, 0)
+        self.assertEqual(actual, 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 - Removes unused --no-unallocated flag. This flag was never used and `--unallocated` is better suited for the use-case.

Fixes #17 